### PR TITLE
 Fix getcandidateEvents function

### DIFF
--- a/streams/windows.bal
+++ b/streams/windows.bal
@@ -528,6 +528,21 @@ public type ExternalTimeWindow object {
                         boolean isLHSTrigger = true)
                         returns (StreamEvent?, StreamEvent?)[] {
         (StreamEvent?, StreamEvent?)[] events;
+        int i = 0;
+        foreach e in expiredEventQueue.asArray() {
+            match e {
+                StreamEvent s => {
+                    StreamEvent lshEvent = (isLHSTrigger) ? originEvent : s;
+                    StreamEvent rhsEvent = (isLHSTrigger) ? s : originEvent;
+                    if (conditionFunc(lshEvent.data, rhsEvent.data)) {
+                        events[i] = (lshEvent, rhsEvent);
+                        i++;
+                    }
+                }
+                any a => {
+                }
+            }
+        }
         return events;
     }
 
@@ -679,6 +694,21 @@ public type ExternalTimeBatchWindow object {
                         boolean isLHSTrigger = true)
                         returns (StreamEvent?, StreamEvent?)[] {
         (StreamEvent?, StreamEvent?)[] events;
+        int i = 0;
+        foreach e in currentEventChunk.asArray() {
+            match e {
+                StreamEvent s => {
+                    StreamEvent lshEvent = (isLHSTrigger) ? originEvent : s;
+                    StreamEvent rhsEvent = (isLHSTrigger) ? s : originEvent;
+                    if (conditionFunc(lshEvent.data, rhsEvent.data)) {
+                        events[i] = (lshEvent, rhsEvent);
+                        i++;
+                    }
+                }
+                any a => {
+                }
+            }
+        }
         return events;
     }
 
@@ -968,6 +998,21 @@ public type TimeLengthWindow object {
                         boolean isLHSTrigger = true)
                         returns (StreamEvent?, StreamEvent?)[] {
         (StreamEvent?, StreamEvent?)[] events;
+        int i = 0;
+        foreach e in expiredEventChunk.asArray() {
+            match e {
+                StreamEvent s => {
+                    StreamEvent lshEvent = (isLHSTrigger) ? originEvent : s;
+                    StreamEvent rhsEvent = (isLHSTrigger) ? s : originEvent;
+                    if (conditionFunc(lshEvent.data, rhsEvent.data)) {
+                        events[i] = (lshEvent, rhsEvent);
+                        i++;
+                    }
+                }
+                any a => {
+                }
+            }
+        }
         return events;
     }
 
@@ -1076,6 +1121,21 @@ public type UniqueLengthWindow object {
                         boolean isLHSTrigger = true)
                         returns (StreamEvent?, StreamEvent?)[] {
         (StreamEvent?, StreamEvent?)[] events;
+        int i = 0;
+        foreach e in expiredEventChunk.asArray() {
+            match e {
+                StreamEvent s => {
+                    StreamEvent lshEvent = (isLHSTrigger) ? originEvent : s;
+                    StreamEvent rhsEvent = (isLHSTrigger) ? s : originEvent;
+                    if (conditionFunc(lshEvent.data, rhsEvent.data)) {
+                        events[i] = (lshEvent, rhsEvent);
+                        i++;
+                    }
+                }
+                any a => {
+                }
+            }
+        }
         return events;
     }
 };

--- a/streams/windows.bal
+++ b/streams/windows.bal
@@ -899,7 +899,7 @@ public type TimeLengthWindow object {
 
     public int timeInMilliSeconds;
     public int length;
-    private int count = 0;
+    public int count = 0;
     public LinkedList expiredEventChunk;
     public function (StreamEvent[])? nextProcessPointer;
     public task:Timer? timer;
@@ -1028,7 +1028,7 @@ public type UniqueLengthWindow object {
     public string uniqueKey;
     public int length;
     public int count = 0;
-    private map uniqueMap;
+    public map uniqueMap;
     public LinkedList expiredEventChunk;
     public function (StreamEvent[])? nextProcessPointer;
 


### PR DESCRIPTION
Purpose of this PR is to implement the 'getCandidateEvents()' functions in externalTimeWindow, externalTimeBatchWindow, timeLengthWindow, and uniqueLengthWindow